### PR TITLE
Allow usage of PascalCase variables.

### DIFF
--- a/TypeScript/tslint.json
+++ b/TypeScript/tslint.json
@@ -19,7 +19,8 @@
     ],
     "variable-name": [
       true,
-      "allow-leading-underscore"
+      "allow-leading-underscore",
+      "allow-pascal-case"
     ],
     "interface-name": false,
     "triple-equals": true,


### PR DESCRIPTION
Especially usefull/required on react components